### PR TITLE
refactor(content): added prev invisible content

### DIFF
--- a/src/blocks/Collage/index.tsx
+++ b/src/blocks/Collage/index.tsx
@@ -260,6 +260,7 @@ export default defineBlock({
     fields: {
       pretitle: {
         type: "text",
+        preview: "New in",
         label: "Pretitle",
         isTranslatable: true,
       },

--- a/src/blocks/Collage/index.tsx
+++ b/src/blocks/Collage/index.tsx
@@ -260,7 +260,7 @@ export default defineBlock({
     fields: {
       pretitle: {
         type: "text",
-        preview: "New in",
+        preview: "Just in",
         label: "Pretitle",
         isTranslatable: true,
       },

--- a/src/blocks/ContentCard/index.tsx
+++ b/src/blocks/ContentCard/index.tsx
@@ -250,7 +250,7 @@ export default defineBlock({
     fields: {
       pretitle: {
         type: "text",
-        preview: "New in",
+        preview: "Just in",
         label: "Pretitle",
         isTranslatable: true,
       },

--- a/src/blocks/ContentCard/index.tsx
+++ b/src/blocks/ContentCard/index.tsx
@@ -250,6 +250,7 @@ export default defineBlock({
     fields: {
       pretitle: {
         type: "text",
+        preview: "New in",
         label: "Pretitle",
         isTranslatable: true,
       },

--- a/src/blocks/ProductSlider/index.tsx
+++ b/src/blocks/ProductSlider/index.tsx
@@ -374,6 +374,7 @@ export default defineBlock({
       pretitle: {
         type: "text",
         label: "Pretitle",
+        preview: "Bestsellers",
         isTranslatable: true,
       },
       title: {
@@ -385,7 +386,7 @@ export default defineBlock({
       subtitle: {
         type: "text",
         label: "Description",
-        preview: "Our most popular items from softshell materials.",
+        preview: "Our most popular items.",
         isTranslatable: true,
       },
       buttons: {

--- a/src/blocks/SocialProof/index.tsx
+++ b/src/blocks/SocialProof/index.tsx
@@ -171,19 +171,19 @@ export default defineBlock({
       pretitle: {
         type: "text",
         label: "Pretitle",
-        preview: "",
+        preview: "From A to Z",
         isTranslatable: true,
       },
       title: {
         type: "text",
         label: "Title",
-        preview: "",
+        preview: "Shop by brand",
         isTranslatable: true,
       },
       subtitle: {
         type: "text",
         label: "Description",
-        preview: "We sell more than 500 brands",
+        preview: "We sell more than 500 brands.",
         isTranslatable: true,
       },
       buttons: {

--- a/src/blocks/SocialProof/index.tsx
+++ b/src/blocks/SocialProof/index.tsx
@@ -143,7 +143,7 @@ export default defineBlock({
           { label: "Top", value: "top" },
           { label: "Bottom", value: "bottom" },
         ],
-        preview: "top",
+        preview: "bottom",
       },
       dividerColor: { type: "color", label: "Divider color" },
       hasDivider: { type: "toggle", label: "Has divider", preview: false },
@@ -190,6 +190,15 @@ export default defineBlock({
         type: "subschema",
         allowed: ["button"],
         max: 1,
+        preview: [
+          {
+            subschema: "button",
+            value: {
+              text: "Discover all",
+              link: "https://a.storyblok.com/f/145828/5000x3333/564e281ca1/force-majeure-du8abwm5z2g-unsplash.jpg",
+            },
+          },
+        ],
       },
       logos: {
         type: "subschema",


### PR DESCRIPTION
@InstantGabe could you take a look at the content? Some sections in development have more content options than in the design (e.g. in the design there might not be a visible pretitle, but most sections have it), so we have some rogue content that needs to be checked. In the first commit you can see I added "new" preview content, would be good if you go over it. I've attached a screenshot of the changes I made